### PR TITLE
fix: change string `/` with `os.PathSeparator`

### DIFF
--- a/cmd/repogen/main.go
+++ b/cmd/repogen/main.go
@@ -188,7 +188,7 @@ func findRootDirPath(module string) (string, error) {
 		return "", errors.New("unable to get working directory")
 	}
 
-	splittedCurrDir := strings.Split(currDirPath, "/")
+	splittedCurrDir := strings.Split(currDirPath, string(os.PathSeparator))
 	splittedModule := strings.Split(module, "/")
 	moduleDir := splittedModule[len(splittedModule)-1]
 	var rootDirPath []string

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -119,7 +119,7 @@ func (gen *Generator) resolveModelPath(modelDest string) string {
 		return modelDest
 	}
 
-	splittedDestPath := strings.Split(destinationPath, "/")
+	splittedDestPath := strings.Split(destinationPath, string(os.PathSeparator))
 	n := len(splittedDestPath)
 	var modelPath []string
 	for i := n - 1; i > 0; i-- {


### PR DESCRIPTION
This PR will be fix error path separator on windows.

When I am using `repogen`, I found error `unable to load env file`.
![image](https://user-images.githubusercontent.com/4019710/147407037-5884e0fe-ecb2-4076-adbf-bec987848882.png)

I asked a friend because I was afraid that I would make a mistake when using `repogen`. It turned out that my friend and I used the same command.

I did some debugging and it turned out that when repogen did strings.Split, the windows path with unix was different.
![147407024-fa9ccd57-522c-4f34-a30f-a36f7a8bec4f](https://user-images.githubusercontent.com/4019710/147407272-47369915-0ad9-4c8a-8601-d5d4a1aa0253.png)

That's why I changed `"/"` to `os.PathSeparator` to handle multiplatform for this command.
