### PR TITLE
fix: missing unimported package for null decimal #5

### DIFF
--- a/parser/gostruct.go
+++ b/parser/gostruct.go
@@ -133,12 +133,12 @@ func snakeToCamel(s string) string {
 func resolveImportedPkg(goFields []*GoField) []string {
 	importedMap := make(map[string]struct{})
 	for _, field := range goFields {
-		if strings.Contains(strings.ToLower(string(field.Type)), "null") {
+		if strings.Contains(strings.ToLower(string(field.Type)), "decimal") {
+			importedMap["github.com/shopspring/decimal"] = struct{}{}
+		} else if strings.Contains(strings.ToLower(string(field.Type)), "null") {
 			importedMap["github.com/guregu/null"] = struct{}{}
 		} else if strings.Contains(strings.ToLower(string(field.Type)), "time") {
 			importedMap["time"] = struct{}{}
-		} else if strings.Contains(strings.ToLower(string(field.Type)), "decimal") {
-			importedMap["github.com/shopspring/decimal"] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
# Description
This PR try to fix error of unimported decimal package on `decimal.NullDecimal` type.


## Before Fixed
![fbefore](https://user-images.githubusercontent.com/10769164/170402744-66db4080-5f3e-4bdd-a113-b09762cf17f2.png)

## After fixed
![fix-gen](https://user-images.githubusercontent.com/40876952/170584702-fdb06deb-de2d-4865-be06-b679e5ec2ca6.png)


## Issue Ticket
This issue has been reported on #5.